### PR TITLE
Fix right shifts

### DIFF
--- a/src/uSendKeys.pas
+++ b/src/uSendKeys.pas
@@ -215,7 +215,7 @@ begin
       if fSequence[I+1] = '<' then
         ShiftIndex := 5;
       if fSequence[I+1] = '>' then
-        ShiftIndex := 9;
+        ShiftIndex := 10;
     end;
     case fSequence[I] of
     '(' : begin


### PR DESCRIPTION
Fix issue where using the right-shift modifier `>` selects the wrong shift value. Fixes #7 